### PR TITLE
Fixed menu selection issue

### DIFF
--- a/hdoc-guide/hdocbook.json
+++ b/hdoc-guide/hdocbook.json
@@ -38,7 +38,7 @@
                         "items": [
                             {
                                 "text": "Getting Started",
-                                "link": "hdoc-guide/getting-started"
+                                "link": "hdoc-guide/getting-started/index"
                             },
                             {
                                 "text": "Simple Edits Workflow",


### PR DESCRIPTION
The left-menu was  broken for "Contribution Guide" as no document was present for Getting Started - fixed. 